### PR TITLE
Update copyright for company name change

### DIFF
--- a/faculty_cli/__init__.py
+++ b/faculty_cli/__init__.py
@@ -1,6 +1,6 @@
 """The command line interface to the Faculty platform."""
 
-# Copyright 2016-2019 ASI Data Science
+# Copyright 2016-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/faculty_cli/auth.py
+++ b/faculty_cli/auth.py
@@ -1,6 +1,6 @@
 """Authenticate with Faculty."""
 
-# Copyright 2016-2019 ASI Data Science
+# Copyright 2016-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/faculty_cli/cli.py
+++ b/faculty_cli/cli.py
@@ -1,6 +1,6 @@
 """Command line interface."""
 
-# Copyright 2016-2019 ASI Data Science
+# Copyright 2016-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/faculty_cli/client.py
+++ b/faculty_cli/client.py
@@ -1,6 +1,6 @@
 """Interact with a Faculty service."""
 
-# Copyright 2016-2019 ASI Data Science
+# Copyright 2016-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/faculty_cli/config.py
+++ b/faculty_cli/config.py
@@ -1,6 +1,6 @@
 """Configuration helpers."""
 
-# Copyright 2016-2019 ASI Data Science
+# Copyright 2016-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/faculty_cli/hound.py
+++ b/faculty_cli/hound.py
@@ -1,6 +1,6 @@
 """Interact with Hound."""
 
-# Copyright 2016-2019 ASI Data Science
+# Copyright 2016-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/faculty_cli/update.py
+++ b/faculty_cli/update.py
@@ -1,6 +1,6 @@
 """Prompt the user to update the Faculty CLI"""
 
-# Copyright 2016-2019 ASI Data Science
+# Copyright 2016-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/faculty_cli/version.py
+++ b/faculty_cli/version.py
@@ -1,6 +1,6 @@
 """Module version information."""
 
-# Copyright 2016-2019 ASI Data Science
+# Copyright 2016-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     long_description_content_type="text/markdown",
     url="https://sherlockml.com",
     author="Faculty",
-    author_email="engineering@asidatascience.com",
+    author_email="opensource@faculty.ai",
     license="Apache Software License",
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     long_description=read_long_description(),
     long_description_content_type="text/markdown",
     url="https://sherlockml.com",
-    author="ASI Data Science",
+    author="Faculty",
     author_email="engineering@asidatascience.com",
     license="Apache Software License",
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 """Setup module for the Faculty CLI."""
 
-# Copyright 2016-2019 ASI Data Science
+# Copyright 2016-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
ASI Data Science (formally "Advanced Skills Initiative Limited", UK company number 08873131) has been renamed "Faculty Science Limited" as of 4th February 2019.