### PR TITLE
Update .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,6 +1,1 @@
-Andrew Brookes <brookesey@yahoo.co.uk> Andrew Brookes <andrew@theasi.co>
-Andrew Crozier <wacrozier@gmail.com> Andrew Crozier <andrew.c@theasi.co>
-Nick Robinson <nick@theasi.co> nick <npr251@gmail.com>
-Pascal Bugnion <pascal@bugnion.org> Pascal Bugnion <pascal.b@theasi.co>
-Pascal Bugnion <pascal@bugnion.org> pbugnion <pascal.b@theasi.co>
-Tomáš Milata <tomas@asidatascience.com> Tomáš Milata <tomas@theasi.co>
+Maitiú Ó Ciaráin <m.ociarain@gmail.com> Maitiu O Ciarain <m.ociarain@gmail.com>


### PR DESCRIPTION
All of the existing entries were redundant since the originally private history was squashed for public release.