### PR TITLE
Generate local credentials file for use with VS Code

### DIFF
--- a/faculty_cli/cli.py
+++ b/faculty_cli/cli.py
@@ -747,7 +747,8 @@ def shell(project, server, ssh_opts):
 @click.argument("project")
 @click.argument("server")
 def creds(project, server):
-    """Generate credentials for a faculty server, save them to a config file in ~/.ssh
+    """Generate credentials for a faculty server, 
+    save them to a config file in ~/.ssh
     For use with VS code server"""
 
     project_id, server_id = _resolve_server(project, server)

--- a/faculty_cli/cli.py
+++ b/faculty_cli/cli.py
@@ -780,7 +780,7 @@ def creds(project, server):
                 filename,
             )
         )
-        with open(os.path.expanduser("~/.ssh/faculty_config"), "a") as fp:
+        with open(os.path.expanduser("~/.ssh/config"), "a") as fp:
             fp.write(config)
 
 

--- a/faculty_cli/cli.py
+++ b/faculty_cli/cli.py
@@ -747,7 +747,7 @@ def shell(project, server, ssh_opts):
 @click.argument("project")
 @click.argument("server")
 def creds(project, server):
-    """Generate credentials for a faculty server, 
+    """Generate credentials for a faculty server,
     save them to a config file in ~/.ssh
     For use with VS code server"""
 

--- a/faculty_cli/cli.py
+++ b/faculty_cli/cli.py
@@ -709,6 +709,7 @@ def instance_types(verbose):
         for type_ in types:
             click.echo(type_.name)
 
+
 @cli.command(context_settings={"ignore_unknown_options": True})
 @click.argument("project")
 @click.argument("server")
@@ -741,6 +742,7 @@ def shell(project, server, ssh_opts):
         cmd += list(ssh_opts)
         _run_ssh_cmd(cmd)
 
+
 @cli.command(context_settings={"ignore_unknown_options": True})
 @click.argument("project")
 @click.argument("server")
@@ -752,21 +754,33 @@ def creds(project, server):
     client = faculty.client("server")
     details = client.get_ssh_details(project_id, server_id)
 
-    with _save_key_to_file(details.key, False, key_name="{}_{}.pem".format(project.lower().replace(" ","_"), server)) as filename:
+    with _save_key_to_file(
+        details.key,
+        False,
+        key_name="{}_{}.pem".format(project.lower().replace(" ", "_"), server),
+    ) as filename:
         config = """
 Host {}_{}
    Hostname {}
    Port {}
    User {}
-   IdentityFile {}""".format(project.lower().replace(" ","_"), server, details.hostname, details.port,
-                details.username, filename)
+   IdentityFile {}""".format(
+            project.lower().replace(" ", "_"),
+            server,
+            details.hostname,
+            details.port,
+            details.username,
+            filename,
+        )
         with open(os.path.expanduser("~/.ssh/faculty_config"), "a") as f:
             f.write(config)
+
 
 @cli.group()
 def environment():
     """Manipulate Faculty server environments."""
     _check_credentials()
+
 
 @environment.command()
 @click.argument("project")

--- a/faculty_cli/cli.py
+++ b/faculty_cli/cli.py
@@ -773,7 +773,7 @@ Host {}_{}
             details.username,
             filename,
         )
-        with open(os.path.expanduser("~/.ssh/faculty_config"), "a") as f:
+        with open(os.path.expanduser("~/.ssh/config"), "a") as f:
             f.write(config)
 
 


### PR DESCRIPTION
This isn't quite ready to go yet and requires some documentation for how to connect a local vs code instance with the vs code server running on the platform.

We will need to think about removing credentials for dead servers.

Maybe rather than only generating the creds for one server at run time we should generate a new creds file each time and populate it with all of the users servers.

The local tests I have done with this and vs code - insiders works very well and provides a nice interface to the platform as well as getting around having the configuration for the vs code instance being shared between users / needing to be updated for each project rather than the users local env