### PR TITLE
Add global `--version` argument

### DIFF
--- a/faculty_cli/cli.py
+++ b/faculty_cli/cli.py
@@ -374,6 +374,9 @@ class FacultyCLIGroup(click.Group):
 
 
 @click.group(cls=FacultyCLIGroup)
+@click.version_option(
+    version=faculty_cli.version.__version__, prog_name="faculty-cli"
+)
 def cli():
     """Command line interface to Faculty."""
     try:


### PR DESCRIPTION
This is a widespread convention amongst command line tools, and adding it allows easier access to the version number (for example, for inclusion in support tickets) than the existing `faculty version` subcommand.

Usage is as follows:

    $ faculty --version
    faculty-cli, version 0.12.0.post0+g5e58d47.d20191030