### PR TITLE
List all servers

### DIFF
--- a/faculty_cli/cli.py
+++ b/faculty_cli/cli.py
@@ -294,6 +294,7 @@ def _server_spec(server):
         memory_gb = "-"
     return machine_type, cpus, memory_gb
 
+
 def _get_ssh_details(project, server):
     project_id, server_id = _resolve_server(project, server)
     client = faculty.client("server")

--- a/faculty_cli/cli.py
+++ b/faculty_cli/cli.py
@@ -37,8 +37,7 @@ import faculty.clients.base
 from faculty.clients.server import (
     DedicatedServerResources,
     ServerStatus,
-    SharedServerResources,
-    ServerSchema,
+    SharedServerResources
 )
 from tabulate import tabulate
 
@@ -229,11 +228,10 @@ def _get_servers(project_id, name=None, status=None):
     return servers
 
 
-def _get_user_servers(user_id, status=None):
+def _list_user_servers(user_id, status=None):
     """List all servers owned by user."""
     client = faculty.client("server")
-    endpoint = "/user/{}/instances".format(user_id)
-    servers = client._get(endpoint, ServerSchema(many=True))
+    servers = client.list_for_user(user_id)
     if status is not None:
         servers = [s for s in servers if s.status == status]
     return servers
@@ -526,7 +524,7 @@ def list_servers(project, all, verbose):
         user_id = _get_authenticated_user_id()
         servers = [
             (server.project_id, projects[server.project_id], server)
-            for server in _get_user_servers(user_id, status=status_filter)
+            for server in _list_user_servers(user_id, status=status_filter)
         ]
     else:
         project_id = _resolve_project(project)

--- a/faculty_cli/cli.py
+++ b/faculty_cli/cli.py
@@ -537,11 +537,13 @@ def _list_all_servers(all, verbose):
     help="Print extra information about servers.",
 )
 def list_servers(project, all, verbose):
-    ("""List your Faculty servers."""
-    """\n\nIf you do not specify a project, all servers will be listed""")
+    (
+        """List your Faculty servers."""
+        """\n\nIf you do not specify a project, all servers will be listed"""
+    )
     if not project:
         return _list_all_servers(all, verbose)
-        
+
     project_id = _resolve_project(project)
 
     status_filter = None if all else ServerStatus.RUNNING

--- a/faculty_cli/cli.py
+++ b/faculty_cli/cli.py
@@ -29,7 +29,6 @@ import textwrap
 import time
 import uuid
 from distutils.version import StrictVersion
-from collections import defaultdict
 import click
 import faculty
 import faculty.config
@@ -512,8 +511,8 @@ def server():
 )
 def list_servers(project, all, verbose):
     """List your Faculty servers.
-    
-    
+
+
     If you do not specify a project, all servers will be listed."""
     status_filter = None if all else ServerStatus.RUNNING
     if not project:
@@ -570,7 +569,6 @@ def list_servers(project, all, verbose):
             click.echo(server[2])
     elif not project and verbose:
         click.echo(tabulate(found_servers, headers, tablefmt="plain"))
-    
 
 
 @server.command(name="open")

--- a/faculty_cli/cli.py
+++ b/faculty_cli/cli.py
@@ -515,9 +515,9 @@ def _list_all_servers(all, verbose):
             else:
                 rows.append((project.name, server.name))
     if verbose and rows:
-        click.echo(tabulate(rows, verbose_headers))
+        click.echo(tabulate(rows, verbose_headers, tablefmt="plain"))
     elif rows:
-        click.echo(tabulate(rows, headers))
+        click.echo(tabulate(rows, headers, tablefmt="plain"))
     else:
         click.echo("No servers.")
 
@@ -541,6 +541,7 @@ def list_servers(project, all, verbose):
     """\n\nIf you do not specify a project, all servers will be listed""")
     if not project:
         return _list_all_servers(all, verbose)
+        
     project_id = _resolve_project(project)
 
     status_filter = None if all else ServerStatus.RUNNING

--- a/faculty_cli/cli.py
+++ b/faculty_cli/cli.py
@@ -180,7 +180,7 @@ def _check_credentials():
 
 
 def _list_projects():
-    """List all projects accessible by user"""
+    """List all projects accessible by user."""
     _check_credentials()
     client = faculty.client("project")
     user_id = faculty_cli.auth.user_id()
@@ -189,7 +189,7 @@ def _list_projects():
 
 
 def _match_project(project):
-    """Find a project by matching its name"""
+    """Find a project by matching its name."""
     projects = _list_projects()
     matching_projects = [p for p in projects if p.name == project]
     if len(matching_projects) == 1:
@@ -226,6 +226,7 @@ def _get_servers(project_id, name=None, status=None):
 
 
 def _get_user_servers(user_id, status=None):
+    """List all servers owned by user."""
     client = faculty.client("server")
     endpoint = "/user/{}/instances".format(user_id)
     servers = client._get(endpoint, ServerSchema(many=True))
@@ -278,7 +279,7 @@ def _resolve_server(project, server=None, ensure_running=True):
 
 
 def _server_spec(server):
-    """Return formatted strings for machine type, cpu and memory of server"""
+    """Return formatted strings for machine type, cpu and memory of server."""
     if isinstance(server.resources, SharedServerResources):
         machine_type = "-"
         cpus = "{:.3g}".format(server.resources.milli_cpus / 1000)
@@ -292,7 +293,6 @@ def _server_spec(server):
 
 def _job_by_name(project_id, job_name):
     """Resolve a project ID and job name to a job ID."""
-
     client = faculty.client("job")
     jobs = client.list(project_id)
     matching_jobs = [job for job in jobs if job.metadata.name == job_name]
@@ -508,7 +508,7 @@ def server():
 def list_servers(provided_project, all, verbose):
     (
         """List your Faculty servers."""
-        """\n\nIf you do not specify a project, all servers will be listed"""
+        """\n\nIf you do not specify a project, all servers will be listed."""
     )
     status_filter = None if all else ServerStatus.RUNNING
     if not provided_project:

--- a/faculty_cli/cli.py
+++ b/faculty_cli/cli.py
@@ -501,9 +501,9 @@ def list_servers(provided_project, all, verbose):
         """\n\nIf you do not specify a project, all servers will be listed"""
     )
     if not provided_project:
-        projects = [project for project in _list_projects()]
+        projects = [(project.id, project.name) for project in _list_projects()]
     else:
-        projects = [_resolve_project(provided_project)]
+        projects = [(_resolve_project(provided_project), "")]
 
     status_filter = None if all else ServerStatus.RUNNING
     headers = (
@@ -519,16 +519,14 @@ def list_servers(provided_project, all, verbose):
         "Started",
     )
     found_servers = []
-    for project in projects:
-        servers = _get_servers(
-            project if provided_project else project.id, status=status_filter
-        )
+    for project_id, project_name in projects:
+        servers = _get_servers(project_id, status=status_filter)
         for server in servers:
             machine_type, cpus, memory_gb = _server_spec(server)
             found_servers.append(
                 (
-                    project.name if not provided_project else "",
-                    project.id if not provided_project else project,
+                    project_name,
+                    project_id,
                     server.name,
                     server.type,
                     machine_type,

--- a/faculty_cli/cli.py
+++ b/faculty_cli/cli.py
@@ -37,7 +37,7 @@ import faculty.clients.base
 from faculty.clients.server import (
     DedicatedServerResources,
     ServerStatus,
-    SharedServerResources
+    SharedServerResources,
 )
 from tabulate import tabulate
 

--- a/faculty_cli/cli.py
+++ b/faculty_cli/cli.py
@@ -188,11 +188,7 @@ def _list_projects():
 
 
 def _match_project(project):
-    project_id = _try_uuid(project)
-    if project_id:
-        client = faculty.client("project")
-        return client.get(project_id)
-
+    """Find a project by matching its name"""
     projects = _list_projects()
     matching_projects = [p for p in projects if p.name == project]
     if len(matching_projects) == 1:
@@ -207,22 +203,16 @@ def _match_project(project):
                 "project ID instead"
             ).format(project)
             raise AmbiguousNameError(msg)
-    return project
-
-
-def _try_uuid(value):
-    "Return a uuid if valid, None otherwise"
-    try:
-        uuid_value = uuid.UUID(value)
-        return uuid_value
-    except ValueError:
-        return None
+    return project.id
 
 
 def _resolve_project(project):
     """Resolve a project name or ID to a project ID."""
-    project_id = _try_uuid(project)
-    return project_id if project_id else _match_project(project).id
+    try:
+        project_id = uuid.UUID(project)
+    except ValueError:
+        project_id = _match_project(project)
+    return project_id
 
 
 def _get_servers(project_id, name=None, status=None):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,8 +1,25 @@
 import pytest
 
-from test.fixtures import PROFILE
+from test.fixtures import PROFILE, USER_ID
 
 
 @pytest.fixture
 def mock_profile(mocker):
     mocker.patch("faculty.config.resolve_profile", return_value=PROFILE)
+
+
+@pytest.fixture
+def mock_update_check(mocker):
+    mocker.patch("faculty_cli.update.check_for_new_release")
+
+
+@pytest.fixture
+def mock_check_credentials(mocker):
+    mocker.patch("faculty_cli.cli._check_credentials")
+
+
+@pytest.fixture
+def mock_user_id(mocker):
+    mocker.patch(
+        "faculty_cli.cli._get_authenticated_user_id", return_value=USER_ID
+    )

--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -1,6 +1,14 @@
 import uuid
+import datetime
 
 from faculty.clients.project import Project
+from faculty.clients.server import (
+    DedicatedServerResources,
+    ServerStatus,
+    SharedServerResources,
+    Server,
+    Service,
+)
 from faculty.config import Profile
 
 
@@ -12,4 +20,38 @@ PROFILE = Profile(
     protocol="https",
     client_id=uuid.uuid4(),
     client_secret="29o9P0q3BZiUDMx4R38haZCOPbuy3p7fGARUBD0a",
+)
+
+SERVER_CREATION_DATE = datetime.datetime(year=2020, month=1, day=1)
+SERVICE = Service(
+    name="test-service",
+    host="test-host",
+    port=8000,
+    scheme="test-scheme",
+    uri="test-uri",
+)
+
+DEDICATED_RESOURCE = DedicatedServerResources(node_type="m4.xlarge")
+SHARED_RESOURCE = SharedServerResources(milli_cpus=1000, memory_mb=4000)
+SHARED_SERVER = Server(
+    id=uuid.uuid4(),
+    project_id=PROJECT.id,
+    owner_id=uuid.uuid4(),
+    name="test-server",
+    type="test-type",
+    resources=SHARED_RESOURCE,
+    created_at=SERVER_CREATION_DATE,
+    status=ServerStatus.RUNNING,
+    services=SERVICE,
+)
+DEDICATED_SERVER = Server(
+    id=uuid.uuid4(),
+    project_id=PROJECT.id,
+    owner_id=uuid.uuid4(),
+    name="test-server",
+    type="test-type",
+    resources=DEDICATED_RESOURCE,
+    created_at=SERVER_CREATION_DATE,
+    status=ServerStatus.RUNNING,
+    services=SERVICE,
 )

--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -42,7 +42,7 @@ SHARED_SERVER = Server(
     resources=SHARED_RESOURCE,
     created_at=SERVER_CREATION_DATE,
     status=ServerStatus.RUNNING,
-    services=SERVICE,
+    services=[SERVICE],
 )
 DEDICATED_SERVER = Server(
     id=uuid.uuid4(),
@@ -53,5 +53,5 @@ DEDICATED_SERVER = Server(
     resources=DEDICATED_RESOURCE,
     created_at=SERVER_CREATION_DATE,
     status=ServerStatus.RUNNING,
-    services=SERVICE,
+    services=[SERVICE],
 )

--- a/test/test_projects.py
+++ b/test/test_projects.py
@@ -19,7 +19,7 @@ def mock_check_credentials(mocker):
 
 @pytest.fixture
 def mock_user_id(mocker):
-    mocker.patch("faculty_cli.auth.user_id", return_value=USER_ID)
+    mocker.patch("faculty_cli.cli._get_user_id", return_value=USER_ID)
 
 
 def test_list_projects(

--- a/test/test_projects.py
+++ b/test/test_projects.py
@@ -19,7 +19,9 @@ def mock_check_credentials(mocker):
 
 @pytest.fixture
 def mock_user_id(mocker):
-    mocker.patch("faculty_cli.cli._get_user_id", return_value=USER_ID)
+    mocker.patch(
+        "faculty_cli.cli._get_authenticated_user_id", return_value=USER_ID
+    )
 
 
 def test_list_projects(

--- a/test/test_projects.py
+++ b/test/test_projects.py
@@ -17,13 +17,6 @@ def mock_check_credentials(mocker):
     mocker.patch("faculty_cli.cli._check_credentials")
 
 
-@pytest.fixture
-def mock_user_id(mocker):
-    mocker.patch(
-        "faculty_cli.cli._get_authenticated_user_id", return_value=USER_ID
-    )
-
-
 def test_list_projects(
     mocker,
     mock_update_check,

--- a/test/test_servers.py
+++ b/test/test_servers.py
@@ -41,6 +41,7 @@ def test_no_servers_verbose(
 ):
     runner = CliRunner()
     mocker.patch("faculty_cli.cli._list_projects", return_value=[PROJECT])
+    mocker.patch("faculty_cli.cli._list_user_servers", return_value=[])
     mocker.patch.object(ServerClient, "_get", return_value=[])
     result = runner.invoke(cli, ["server", "list", "-v"])
     assert result.exit_code == 0
@@ -56,7 +57,7 @@ def test_list_all_servers_no_servers(
 ):
     runner = CliRunner()
     mocker.patch("faculty_cli.cli._list_projects", return_value=[PROJECT])
-    mocker.patch("faculty_cli.cli._get_servers", return_value=[])
+    mocker.patch("faculty_cli.cli._list_user_servers", return_value=[])
     result = runner.invoke(cli, ["server", "list"])
     assert result.exit_code == 0
     assert result.output == ""
@@ -151,8 +152,6 @@ def test_list_servers_verbose(
     mock_user_id,
 ):
     runner = CliRunner()
-
-    schema_mock = mocker.patch("faculty.clients.server.ServerSchema")
     mocker.patch(
         "faculty_cli.cli._get_servers", return_value=[DEDICATED_SERVER]
     )

--- a/test/test_servers.py
+++ b/test/test_servers.py
@@ -38,10 +38,9 @@ def test_list_all_servers(
     mock_user_id,
 ):
     runner = CliRunner()
-
-    schema_mock = mocker.patch("faculty.clients.server.ServerSchema")
-    mocker.patch.object(ServerClient, "_get", return_value=[DEDICATED_SERVER])
     mocker.patch("faculty_cli.cli._list_projects", return_value=[PROJECT])
+    schema_mock = mocker.patch("faculty_cli.cli.ServerSchema")
+    mocker.patch.object(ServerClient, "_get", return_value=[DEDICATED_SERVER])
     result = runner.invoke(cli, ["server", "list"])
     assert result.exit_code == 0
     assert (
@@ -54,9 +53,7 @@ def test_list_all_servers(
         + "\n"
     )
     ServerClient._get.assert_called_once_with(
-        "/instance/{}".format(PROJECT.id),
-        schema_mock.return_value,
-        params=None,
+        "/user/{}/instances".format(USER_ID), schema_mock.return_value
     )
 
 
@@ -68,10 +65,9 @@ def test_list_all_servers_verbose(
     mock_user_id,
 ):
     runner = CliRunner()
-
-    schema_mock = mocker.patch("faculty.clients.server.ServerSchema")
-    mocker.patch.object(ServerClient, "_get", return_value=[DEDICATED_SERVER])
+    schema_mock = mocker.patch("faculty_cli.cli.ServerSchema")
     mocker.patch("faculty_cli.cli._list_projects", return_value=[PROJECT])
+    mocker.patch.object(ServerClient, "_get", return_value=[DEDICATED_SERVER])
     result = runner.invoke(cli, ["server", "list", "--verbose"])
     assert result.exit_code == 0
     assert (
@@ -108,9 +104,7 @@ def test_list_all_servers_verbose(
         + "\n"
     )
     ServerClient._get.assert_called_once_with(
-        "/instance/{}".format(PROJECT.id),
-        schema_mock.return_value,
-        params=None,
+        "/user/{}/instances".format(USER_ID), schema_mock.return_value
     )
 
 

--- a/test/test_servers.py
+++ b/test/test_servers.py
@@ -27,7 +27,9 @@ def mock_check_credentials(mocker):
 
 @pytest.fixture
 def mock_user_id(mocker):
-    mocker.patch("faculty_cli.cli._get_user_id", return_value=USER_ID)
+    mocker.patch(
+        "faculty_cli.cli._get_authenticated_user_id", return_value=USER_ID
+    )
 
 
 def test_no_servers_verbose(

--- a/test/test_servers.py
+++ b/test/test_servers.py
@@ -1,0 +1,205 @@
+from test.test_projects import mock_check_credentials
+import pytest
+from tabulate import tabulate
+from click.testing import CliRunner
+
+from faculty_cli.cli import cli, _list_projects, _server_spec
+
+from faculty.clients.server import ServerClient
+import faculty.clients.base
+from test.fixtures import (
+    PROJECT,
+    SHARED_SERVER,
+    DEDICATED_SERVER,
+    DEDICATED_RESOURCE,
+    SHARED_RESOURCE,
+    USER_ID,
+)
+
+
+@pytest.fixture
+def mock_update_check(mocker):
+    mocker.patch("faculty_cli.update.check_for_new_release")
+
+
+@pytest.fixture
+def mock_check_credentials(mocker):
+    mocker.patch("faculty_cli.cli._check_credentials")
+
+
+@pytest.fixture
+def mock_user_id(mocker):
+    mocker.patch("faculty_cli.auth.user_id", return_value=USER_ID)
+
+
+def test_list_all_servers(
+    mocker,
+    mock_update_check,
+    mock_check_credentials,
+    mock_profile,
+    mock_user_id,
+):
+    runner = CliRunner()
+
+    schema_mock = mocker.patch("faculty.clients.server.ServerSchema")
+    mocker.patch.object(ServerClient, "_get", return_value=[DEDICATED_SERVER])
+    mocker.patch("faculty_cli.cli._list_projects", return_value=[PROJECT])
+    result = runner.invoke(cli, ["server", "list"])
+    assert result.exit_code == 0
+    assert (
+        result.output
+        == tabulate(
+            [(PROJECT.name, DEDICATED_SERVER.name)],
+            ("Project", "Server"),
+            tablefmt="plain",
+        )
+        + "\n"
+    )
+    ServerClient._get.assert_called_once_with(
+        "/instance/{}".format(PROJECT.id),
+        schema_mock.return_value,
+        params=None,
+    )
+
+
+def test_list_all_servers_verbose(
+    mocker,
+    mock_update_check,
+    mock_check_credentials,
+    mock_profile,
+    mock_user_id,
+):
+    runner = CliRunner()
+
+    schema_mock = mocker.patch("faculty.clients.server.ServerSchema")
+    mocker.patch.object(ServerClient, "_get", return_value=[DEDICATED_SERVER])
+    mocker.patch("faculty_cli.cli._list_projects", return_value=[PROJECT])
+    result = runner.invoke(cli, ["server", "list", "--verbose"])
+    assert result.exit_code == 0
+    assert (
+        result.output
+        == tabulate(
+            [
+                (
+                    PROJECT.name,
+                    PROJECT.id,
+                    DEDICATED_SERVER.name,
+                    DEDICATED_SERVER.type,
+                    DEDICATED_RESOURCE.node_type,
+                    "-",
+                    "-",
+                    DEDICATED_SERVER.status.value,
+                    DEDICATED_SERVER.id,
+                    DEDICATED_SERVER.created_at.strftime("%Y-%m-%d %H:%M"),
+                )
+            ],
+            (
+                "Project Name",
+                "Project ID",
+                "Server Name",
+                "Type",
+                "Machine Type",
+                "CPUs",
+                "RAM",
+                "Status",
+                "Server ID",
+                "Started",
+            ),
+            tablefmt="plain",
+        )
+        + "\n"
+    )
+    ServerClient._get.assert_called_once_with(
+        "/instance/{}".format(PROJECT.id),
+        schema_mock.return_value,
+        params=None,
+    )
+
+
+def test_list_servers(
+    mocker,
+    mock_update_check,
+    mock_check_credentials,
+    mock_profile,
+    mock_user_id,
+):
+    runner = CliRunner()
+
+    schema_mock = mocker.patch("faculty.clients.server.ServerSchema")
+    mocker.patch.object(ServerClient, "_get", return_value=[DEDICATED_SERVER])
+    mocker.patch("faculty_cli.cli._resolve_project", return_value=PROJECT.id)
+    result = runner.invoke(cli, ["server", "list", "{}".format(PROJECT.id)])
+    assert result.exit_code == 0
+    assert result.output == DEDICATED_SERVER.name + "\n"
+    ServerClient._get.assert_called_once_with(
+        "/instance/{}".format(PROJECT.id),
+        schema_mock.return_value,
+        params=None,
+    )
+
+
+def test_list_servers_verbose(
+    mocker,
+    mock_update_check,
+    mock_check_credentials,
+    mock_profile,
+    mock_user_id,
+):
+    runner = CliRunner()
+
+    schema_mock = mocker.patch("faculty.clients.server.ServerSchema")
+    mocker.patch.object(ServerClient, "_get", return_value=[DEDICATED_SERVER])
+    mocker.patch("faculty_cli.cli._resolve_project", return_value=PROJECT.id)
+    result = runner.invoke(
+        cli, ["server", "list", "{}".format(PROJECT.id), "--verbose"]
+    )
+    assert result.exit_code == 0
+    assert (
+        result.output
+        == tabulate(
+            [
+                (
+                    DEDICATED_SERVER.name,
+                    DEDICATED_SERVER.type,
+                    DEDICATED_RESOURCE.node_type,
+                    "-",
+                    "-",
+                    DEDICATED_SERVER.status.value,
+                    DEDICATED_SERVER.id,
+                    DEDICATED_SERVER.created_at.strftime("%Y-%m-%d %H:%M"),
+                )
+            ],
+            (
+                "Server Name",
+                "Type",
+                "Machine Type",
+                "CPUs",
+                "RAM",
+                "Status",
+                "ID",
+                "Started",
+            ),
+            tablefmt="plain",
+        )
+        + "\n"
+    )
+
+    ServerClient._get.assert_called_once_with(
+        "/instance/{}".format(PROJECT.id),
+        schema_mock.return_value,
+        params=None,
+    )
+
+
+def test_server_spec_dedicated():
+    machine_type, cpus, memory_gb = _server_spec(DEDICATED_SERVER)
+    assert machine_type == DEDICATED_RESOURCE.node_type
+    assert cpus == "-"
+    assert memory_gb == "-"
+
+
+def test_server_spec_shared():
+    machine_type, cpus, memory_gb = _server_spec(SHARED_SERVER)
+    assert machine_type == "-"
+    assert cpus == "{:.3g}".format(SHARED_RESOURCE.milli_cpus / 1000)
+    assert memory_gb == "{:.3g}GB".format(SHARED_RESOURCE.memory_mb / 1000)

--- a/test/test_servers.py
+++ b/test/test_servers.py
@@ -1,12 +1,10 @@
-from test.test_projects import mock_check_credentials
 import pytest
 from tabulate import tabulate
 from click.testing import CliRunner
 
-from faculty_cli.cli import cli, _list_projects, _server_spec
+from faculty_cli.cli import cli, _server_spec
 
 from faculty.clients.server import ServerClient
-import faculty.clients.base
 from test.fixtures import (
     PROJECT,
     SHARED_SERVER,

--- a/test/test_servers.py
+++ b/test/test_servers.py
@@ -1,5 +1,3 @@
-import pytest
-
 from click.testing import CliRunner
 
 from faculty_cli.cli import cli, _server_spec
@@ -11,25 +9,7 @@ from test.fixtures import (
     DEDICATED_SERVER,
     DEDICATED_RESOURCE,
     SHARED_RESOURCE,
-    USER_ID,
 )
-
-
-@pytest.fixture
-def mock_update_check(mocker):
-    mocker.patch("faculty_cli.update.check_for_new_release")
-
-
-@pytest.fixture
-def mock_check_credentials(mocker):
-    mocker.patch("faculty_cli.cli._check_credentials")
-
-
-@pytest.fixture
-def mock_user_id(mocker):
-    mocker.patch(
-        "faculty_cli.cli._get_authenticated_user_id", return_value=USER_ID
-    )
 
 
 def test_no_servers_verbose(
@@ -100,7 +80,6 @@ def test_list_all_servers_verbose(
         [
             (
                 PROJECT.name,
-                PROJECT.id,
                 DEDICATED_SERVER.name,
                 DEDICATED_SERVER.type,
                 DEDICATED_RESOURCE.node_type,
@@ -113,7 +92,6 @@ def test_list_all_servers_verbose(
         ],
         (
             "Project Name",
-            "Project ID",
             "Server Name",
             "Type",
             "Machine Type",

--- a/test/test_servers.py
+++ b/test/test_servers.py
@@ -50,7 +50,7 @@ def test_list_all_servers(
         result.output
         == tabulate(
             [(PROJECT.name, DEDICATED_SERVER.name)],
-            ("Project", "Server"),
+            ("Project Name", "Server Name"),
             tablefmt="plain",
         )
         + "\n"
@@ -176,7 +176,7 @@ def test_list_servers_verbose(
                 "CPUs",
                 "RAM",
                 "Status",
-                "ID",
+                "Server ID",
                 "Started",
             ),
             tablefmt="plain",


### PR DESCRIPTION
Servers now lists all servers when not provided with a project uuid/name:

`faculty servers list`

Having an optional argument isn't ideal, but neither is having a separate command (I tried something like list-all but that seemed pretty clunky). 

What definitely isn't ideal is having to call get on each project to collate the servers. I'm guessing this will take a while for users with a large numbers of projects, but without an endpoint I don't know how else to do it. I also can't print as the servers are accumulating as that would mess up the tabular formatting.

Closes #25 
