### PR TITLE
Add helper output for connecting after running add-to-ssh-agent

### DIFF
--- a/faculty_cli/cli.py
+++ b/faculty_cli/cli.py
@@ -738,11 +738,8 @@ def ssh(project, server):
     click.echo(
         "\n"
         + "Login to the server with:\n"
-        + "ssh {}@{} -p {}".format(
-            details.username, details.hostname, details.port
-        )
-        + " -o UserKnownHostsFile={} -o StrictHostKeyChecking=no".format(
-            os.devnull
+        + "ssh {}@{} -p {} -o UserKnownHostsFile={} -o StrictHostKeyChecking=no".format(
+            details.username, details.hostname, details.port, os.devnull
         )
     )
 

--- a/faculty_cli/cli.py
+++ b/faculty_cli/cli.py
@@ -739,7 +739,7 @@ def ssh(project, server):
         "\n"
         + "Connect to the server by:\n"
         + "ssh {}@{} -p {} -o UserKnownHostsFile={} -o StrictHostKeyChecking=no".format(
-            details.username, details.hostname, details.port, os.devnull,
+            details.username, details.hostname, details.port, os.devnull
         )
     )
 

--- a/faculty_cli/cli.py
+++ b/faculty_cli/cli.py
@@ -735,6 +735,15 @@ def ssh(project, server):
             tablefmt="plain",
         )
     )
+    click.echo(
+        "\n".join(
+            [
+                "",
+                "Connect to the server by:",
+                f"ssh {details.username}@{details.hostname} -p {details.port} -o UserKnownHostsFile={os.devnull} -o StrictHostKeyChecking=no",
+            ]
+        )
+    )
 
 
 @cli.command(context_settings={"ignore_unknown_options": True})

--- a/faculty_cli/cli.py
+++ b/faculty_cli/cli.py
@@ -736,17 +736,10 @@ def ssh(project, server):
         )
     )
     click.echo(
-        "\n".join(
-            [
-                "",
-                "Connect to the server by:",
-                "ssh {username}@{password} -p {port} -o UserKnownHostsFile={devnull} -o StrictHostKeyChecking=no".format(
-                    username=details.username,
-                    password=details.hostname,
-                    port=details.port,
-                    devnull=os.devnull,
-                ),
-            ]
+        "\n"
+        + "Connect to the server by:\n"
+        + "ssh {}@{} -p {} -o UserKnownHostsFile={} -o StrictHostKeyChecking=no".format(
+            details.username, details.hostname, details.port, os.devnull,
         )
     )
 

--- a/faculty_cli/cli.py
+++ b/faculty_cli/cli.py
@@ -740,7 +740,12 @@ def ssh(project, server):
             [
                 "",
                 "Connect to the server by:",
-                f"ssh {details.username}@{details.hostname} -p {details.port} -o UserKnownHostsFile={os.devnull} -o StrictHostKeyChecking=no",
+                "ssh {username}@{password} -p {port} -o UserKnownHostsFile={devnull} -o StrictHostKeyChecking=no".format(
+                    username=details.username,
+                    password=details.hostname,
+                    port=details.port,
+                    devnull=os.devnull,
+                ),
             ]
         )
     )

--- a/faculty_cli/cli.py
+++ b/faculty_cli/cli.py
@@ -737,9 +737,12 @@ def ssh(project, server):
     )
     click.echo(
         "\n"
-        + "Connect to the server by:\n"
-        + "ssh {}@{} -p {} -o UserKnownHostsFile={} -o StrictHostKeyChecking=no".format(
-            details.username, details.hostname, details.port, os.devnull
+        + "Login to the server with:\n"
+        + "ssh {}@{} -p {}".format(
+            details.username, details.hostname, details.port
+        )
+        + " -o UserKnownHostsFile={} -o StrictHostKeyChecking=no".format(
+            os.devnull
         )
     )
 

--- a/faculty_cli/cli.py
+++ b/faculty_cli/cli.py
@@ -1167,7 +1167,7 @@ def put(project, local, remote, server):
                 "-P",
                 str(details.port),
                 os.path.expanduser(local),
-                u"{}@{}:{}".format(
+                "{}@{}:{}".format(
                     details.username, details.hostname, escaped_remote
                 ),
             ]
@@ -1199,7 +1199,7 @@ def get(project, remote, local, server):
                 filename,
                 "-P",
                 str(details.port),
-                u"{}@{}:{}".format(
+                "{}@{}:{}".format(
                     details.username, details.hostname, escaped_remote
                 ),
                 os.path.expanduser(local),
@@ -1219,11 +1219,11 @@ def _rsync(project, local, remote, server, rsync_opts, up):
     escaped_remote = faculty_cli.shell.quote(remote)
     if up:
         path_from = local
-        path_to = u"{}@{}:{}".format(
+        path_to = "{}@{}:{}".format(
             details.username, details.hostname, escaped_remote
         )
     else:
-        path_from = u"{}@{}:{}".format(
+        path_from = "{}@{}:{}".format(
             details.username, details.hostname, escaped_remote
         )
         path_to = local

--- a/tox.ini
+++ b/tox.ini
@@ -22,3 +22,10 @@ deps =
     black==18.9b0
 commands =
     black {posargs:--check setup.py faculty_cli test}
+
+# This section is in use Python 2 is supported
+# With Python 3 flake8-black would unify the requirements
+# of the formatter and linter.
+[flake8]
+# Longer line length is due to black's default line wrap
+max-line-length = 88

--- a/tox.ini
+++ b/tox.ini
@@ -22,3 +22,7 @@ deps =
     black==18.9b0
 commands =
     black {posargs:--check setup.py faculty_cli test}
+
+[flake8]
+# Ignore long line errors, and rely on the formatting done properly by black
+ignore = E501

--- a/tox.ini
+++ b/tox.ini
@@ -25,4 +25,5 @@ commands =
 
 [flake8]
 # Ignore long line errors, and rely on the formatting done properly by black
-ignore = E501
+# Also ignore "Line break occurred before a binary operator" also coming from black
+ignore = E501,W503

--- a/tox.ini
+++ b/tox.ini
@@ -13,9 +13,8 @@ commands = pytest {posargs}
 skip_install = True
 deps =
     flake8
-    flake8-black
 commands =
-    flake8 --select BLK
+    flake8
 
 [testenv:black]
 skip_install = True

--- a/tox.ini
+++ b/tox.ini
@@ -22,10 +22,3 @@ deps =
     black==18.9b0
 commands =
     black {posargs:--check setup.py faculty_cli test}
-
-# This section is in use Python 2 is supported
-# With Python 3 flake8-black would unify the requirements
-# of the formatter and linter.
-[flake8]
-# Longer line length is due to black's default line wrap
-max-line-length = 88

--- a/tox.ini
+++ b/tox.ini
@@ -13,8 +13,9 @@ commands = pytest {posargs}
 skip_install = True
 deps =
     flake8
+    flake8-black
 commands =
-    flake8
+    flake8 --select BLK
 
 [testenv:black]
 skip_install = True


### PR DESCRIPTION
The function definition header has help how to connect to the server whose key we've added to the ssh-agent, on the other hand the tabular output is both different order and would still require knowledge of the ssh parameters.

This change fills in the command with the server variables and adds some extra flags that help to be less noisy later: not adding the server's key to the known hosts file, and not checking the server's key.

```
Hostname          Port  Username
123.123.123.123   12345  faculty

Connect to the server by:
ssh faculty@123.123.123.123 -p 12345 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
```

It should work both on Linux/Mac and Windows as the relevant null device is substituted in the command example.

Signed-off-by: Gergely Imreh <gergely.imreh@faculty.ai>