### PR TITLE
Remove Python 3.4 support and update copyright date

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ matrix:
       env: TOXENV=flake8
     - python: 2.7
       env: TOXENV=py27
-    - python: 3.4
-      env: TOXENV=py34
     - python: 3.5
       env: TOXENV=py35
     - python: 3.6

--- a/faculty_cli/__init__.py
+++ b/faculty_cli/__init__.py
@@ -1,6 +1,6 @@
 """The command line interface to the Faculty platform."""
 
-# Copyright 2016-2019 Faculty Science Limited
+# Copyright 2016-2020 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/faculty_cli/auth.py
+++ b/faculty_cli/auth.py
@@ -1,6 +1,6 @@
 """Authenticate with Faculty."""
 
-# Copyright 2016-2019 Faculty Science Limited
+# Copyright 2016-2020 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/faculty_cli/cli.py
+++ b/faculty_cli/cli.py
@@ -1,6 +1,6 @@
 """Command line interface."""
 
-# Copyright 2016-2019 Faculty Science Limited
+# Copyright 2016-2020 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -1326,9 +1326,7 @@ def ls(project, path):
     try:
         [directory_details] = directory_details_list
     except ValueError:
-        _print_and_exit(
-            "Zero or more than one objects returned".format(path), 70
-        )
+        _print_and_exit("Zero or more than one objects returned", 70)
 
     for item in directory_details.content:
         if hasattr(item, "content"):

--- a/faculty_cli/client.py
+++ b/faculty_cli/client.py
@@ -1,6 +1,6 @@
 """Interact with a Faculty service."""
 
-# Copyright 2016-2019 Faculty Science Limited
+# Copyright 2016-2020 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/faculty_cli/config.py
+++ b/faculty_cli/config.py
@@ -1,6 +1,6 @@
 """Configuration helpers."""
 
-# Copyright 2016-2019 Faculty Science Limited
+# Copyright 2016-2020 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/faculty_cli/hound.py
+++ b/faculty_cli/hound.py
@@ -1,6 +1,6 @@
 """Interact with Hound."""
 
-# Copyright 2016-2019 Faculty Science Limited
+# Copyright 2016-2020 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/faculty_cli/update.py
+++ b/faculty_cli/update.py
@@ -1,6 +1,6 @@
 """Prompt the user to update the Faculty CLI."""
 
-# Copyright 2016-2019 Faculty Science Limited
+# Copyright 2016-2020 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/faculty_cli/version.py
+++ b/faculty_cli/version.py
@@ -1,6 +1,6 @@
 """Module version information."""
 
-# Copyright 2016-2019 Faculty Science Limited
+# Copyright 2016-2020 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 """Setup module for the Faculty CLI."""
 
-# Copyright 2016-2019 Faculty Science Limited
+# Copyright 2016-2020 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35,36,37,38}, flake8, black
+envlist = py{27,35,36,37,38}, flake8, black
 
 [testenv]
 sitepackages = False


### PR DESCRIPTION
This PR removes support for python 3.4 and updates the copyright notice to include 2020. Both these issues were raised here: https://github.com/facultyai/faculty-cli/pull/39