### PR TITLE
Add template to project from directory

### DIFF
--- a/faculty_cli/cli.py
+++ b/faculty_cli/cli.py
@@ -1501,12 +1501,15 @@ def clone(template, version, directory):
 
 
 @template.command()
-@click.argument("project_identifier")
+@click.argument("target_project_identifier")
 @click.argument(
     "source_directory", default=os.getcwd(), type=click.Path(), required=False
 )
 @click.option(
-    "--target-directory", default="/", help="The optional target directory."
+    "-t",
+    "--target-directory",
+    default="/",
+    help="The optional target directory.",
 )
 @click.option(
     "parameters",
@@ -1517,17 +1520,55 @@ def clone(template, version, directory):
     help="Template parameters as key value pairs",
     multiple=True,
 )
-def apply_from_directory(
-    project_identifier, source_directory, target_directory, parameters
+def add_to_project_from_directory(
+    target_project_identifier, source_directory, target_directory, parameters
 ):
     """Apply from a directory to a project."""
-    project_id = _resolve_project(project_identifier)
-    print(project_id)
-    print(source_directory)
-    print(target_directory)
+    template_client = faculty.client("template")
+    notification_client = faculty.client("notification")
 
-    for key, value in parameters:
-        print(key, value)
+    user_id = _get_authenticated_user_id()
+    target_project_id = _resolve_project(target_project_identifier)
+    source_project_id = get_context().project_id
+    if not source_project_id:
+        _print_and_exit(
+            "This command is meant to be used from inside a Faculty server.",
+            64,
+        )
+
+    abs_src_dir = os.path.abspath(source_directory)
+    if not (abs_src_dir == "/project" or abs_src_dir.startswith("/project/")):
+        _print_and_exit(
+            "Source directory must be under /project. "
+            "This command is meant to be used from inside a Faculty server.",
+            64,
+        )
+    src_dir_in_project = _path_in_project(abs_src_dir)
+
+    notifications = notification_client.get_add_to_project_from_dir_notifications(
+        user_id, target_project_id
+    )
+    # Start collecting events before publishing so we don't lose our event
+    try:
+        template_client.add_to_project_from_directory(
+            source_project_id,
+            src_dir_in_project,
+            target_project_id,
+            target_directory,
+            parameters,
+        )
+    except (faculty.clients.template.TemplateException) as e:
+        _print_and_exit(e, 64)
+
+    try:
+        notifications.wait_for_completion()
+        click.echo(
+            "Successfully applied template to project {}.".format(
+                target_project_identifier
+            )
+        )
+    except TemplatePublishingError as err:
+        _print_and_exit(err, 64)
 
 
 @template.command()

--- a/faculty_cli/cli.py
+++ b/faculty_cli/cli.py
@@ -1545,7 +1545,7 @@ def add_to_project_from_directory(
         )
     src_dir_in_project = _path_in_project(abs_src_dir)
 
-    notifications = notification_client.get_add_to_project_from_dir_notifications(
+    notifications = notification_client.add_to_project_from_dir_notifications(
         user_id, target_project_id
     )
     # Start collecting events before publishing so we don't lose our event
@@ -1632,7 +1632,7 @@ def publish_new_template(template, source_directory):
         )
     src_dir_in_project = _path_in_project(abs_src_dir)
 
-    notifications = notification_client.get_publish_template_notifications(
+    notifications = notification_client.publish_template_notifications(
         user_id, project_id
     )
     # Start collecting events before publishing so we don't lose our event

--- a/faculty_cli/cli.py
+++ b/faculty_cli/cli.py
@@ -1638,8 +1638,8 @@ def publish_new_template(template, source_directory):
     # Start collecting events before publishing so we don't lose our event
     try:
         template_client.publish_new(project_id, template, src_dir_in_project)
-    except faculty.clients.base.BadRequest as err:
-        _print_and_exit(err.error, 64)
+    except faculty.clients.template.TemplateException as e:
+        _print_and_exit(templates.publishing_error_message(e), 64)
     try:
         notifications.wait_for_completion()
         click.echo("Successfully published template `{}`.".format(template))

--- a/faculty_cli/cli.py
+++ b/faculty_cli/cli.py
@@ -53,7 +53,6 @@ import faculty_cli.shell
 import faculty_cli.update
 import faculty_cli.version
 import faculty_cli.templates
-from faculty_cli import templates
 
 SSH_OPTIONS = [
     "-o",
@@ -1558,7 +1557,7 @@ def add_to_project_from_directory(
             dict(parameters),
         )
     except faculty.clients.template.TemplateException as e:
-        _print_and_exit(templates.publishing_error_message(e), 64)
+        _print_and_exit(faculty_cli.templates.publishing_error_message(e), 64)
 
     try:
         notifications.wait_for_completion()
@@ -1639,7 +1638,7 @@ def publish_new_template(template, source_directory):
     try:
         template_client.publish_new(project_id, template, src_dir_in_project)
     except faculty.clients.template.TemplateException as e:
-        _print_and_exit(templates.publishing_error_message(e), 64)
+        _print_and_exit(faculty_cli.templates.publishing_error_message(e), 64)
     try:
         notifications.wait_for_completion()
         click.echo("Successfully published template `{}`.".format(template))

--- a/faculty_cli/cli.py
+++ b/faculty_cli/cli.py
@@ -53,7 +53,7 @@ import faculty_cli.shell
 import faculty_cli.update
 import faculty_cli.version
 import faculty_cli.templates
-
+from faculty_cli import templates
 
 SSH_OPTIONS = [
     "-o",
@@ -1555,10 +1555,10 @@ def add_to_project_from_directory(
             src_dir_in_project,
             target_project_id,
             target_directory,
-            parameters,
+            dict(parameters),
         )
-    except (faculty.clients.template.TemplateException) as e:
-        _print_and_exit(e, 64)
+    except faculty.clients.template.TemplateException as e:
+        _print_and_exit(templates.publishing_error_message(e), 64)
 
     try:
         notifications.wait_for_completion()

--- a/faculty_cli/templates.py
+++ b/faculty_cli/templates.py
@@ -51,7 +51,7 @@ def create_blank_template():
     _write_yaml(EMPTY_PARAMETERS_YAML, "parameters.yaml")
 
 
-def publishing_error_message(error: TemplateException):
+def publishing_error_message(error):
     formatters = {
         DefaultParametersParsingError: _simple_error_formatter,
         ResourceValidationFailure: _resource_validation_error,

--- a/faculty_cli/templates.py
+++ b/faculty_cli/templates.py
@@ -16,6 +16,14 @@
 
 import os
 
+from faculty.clients.template import (
+    TemplateException,
+    TemplateRetrievalFailure,
+    ResourceValidationFailure,
+    DefaultParametersParsingError,
+    ParameterValidationFailure,
+)
+
 EMPTY_PARAMETERS_YAML = """
 # This file describes the parameters used in the interpolation of your
 # template. Each parameter has a name, description and type that help users of
@@ -40,3 +48,74 @@ def create_blank_template():
             parameters.write(yaml_content)
 
     _write_yaml(EMPTY_PARAMETERS_YAML, "parameters.yaml")
+
+
+def publishing_error_message(error: TemplateException):
+    formatters = {
+        DefaultParametersParsingError: _default_params_error,
+        ResourceValidationFailure: _resource_validation_error,
+        ParameterValidationFailure: _parameter_validation_error,
+        TemplateRetrievalFailure: _retrieval_error,
+    }
+    formatter = formatters.get(type(error), _default_error_message)
+    return formatter(error)
+
+
+def _default_error_message(*args):
+    return "Unknown template error"
+
+
+def _map_prefix(prefix, errors):
+    return [prefix + e for e in errors]
+
+
+def _one_per_line(error_message_lists):
+    messages = [msg for sublist in error_message_lists for msg in sublist]
+    return "\n".join(messages)
+
+
+def _default_params_error(error):
+    return error.error
+
+
+def _parameter_validation_error(errors):
+    return _map_prefix("Parameter validation failed:", errors.errors)
+
+
+def _retrieval_error(error):
+    message_lists = [
+        _map_prefix(prefix, errors)
+        for prefix, errors in [
+            ("Error reading app resource definition: ", error.apps),
+            ("Error reading API resource definition: ", error.apis),
+            ("Error reading environment resource definition: ", error.envs),
+            ("Error reading app job definition: ", error.jobs),
+        ]
+    ]
+    return _one_per_line(message_lists)
+
+
+def _resource_validation_error(error):
+    apps = error.apps
+    apis = error.apis
+    envs = error.environments
+    jobs = error.jobs
+    workspace = error.workspace
+    message_lists = [
+        _map_prefix(prefix, errors)
+        for prefix, errors in [
+            ("App subdomain already exists: ", apps.subdomain_conflicts),
+            ("App name already exists: ", apps.name_conflicts),
+            ("Invalid app working directory: ", apps.invalid_working_dirs),
+            ("API subdomain already exists: ", apis.subdomain_conflicts),
+            ("API name already exists: ", apis.name_conflicts),
+            ("Invalid API working directory: ", apis.invalid_working_dirs),
+            ("Environment name already exists: ", envs.name_conflicts),
+            ("Invalid environment name: ", envs.invalid_names),
+            ("Job name already exists: ", jobs.name_conflicts),
+            ("Invalid job name: ", jobs.invalid_names),
+            ("Invalid job working directory: ", jobs.invalid_working_dirs),
+            ("Workspace file conflicts: ", workspace.name_conflicts),
+        ]
+    ]
+    return _one_per_line(message_lists)

--- a/faculty_cli/templates.py
+++ b/faculty_cli/templates.py
@@ -91,7 +91,10 @@ def _retrieval_error(error):
         for prefix, errors in [
             ("Error reading app resource definition: ", error.apps),
             ("Error reading API resource definition: ", error.apis),
-            ("Error reading environment resource definition: ", error.environments),
+            (
+                "Error reading environment resource definition: ",
+                error.environments,
+            ),
             ("Error reading app job definition: ", error.jobs),
         ]
     ]

--- a/faculty_cli/templates.py
+++ b/faculty_cli/templates.py
@@ -17,7 +17,6 @@
 import os
 
 from faculty.clients.template import (
-    TemplateException,
     TemplateRetrievalFailure,
     ResourceValidationFailure,
     DefaultParametersParsingError,

--- a/faculty_cli/templates.py
+++ b/faculty_cli/templates.py
@@ -17,10 +17,10 @@
 import os
 
 from faculty.clients.template import (
-    TemplateRetrievalFailure,
-    ResourceValidationFailure,
+    TemplateRetrievalError,
+    ResourceValidationError,
     DefaultParametersParsingError,
-    ParameterValidationFailure,
+    ParameterValidationError,
     GenericParsingError,
 )
 
@@ -53,9 +53,9 @@ def create_blank_template():
 def publishing_error_message(error):
     formatters = {
         DefaultParametersParsingError: _simple_error_formatter,
-        ResourceValidationFailure: _resource_validation_error,
-        ParameterValidationFailure: _parameter_validation_error,
-        TemplateRetrievalFailure: _retrieval_error,
+        ResourceValidationError: _resource_validation_error,
+        ParameterValidationError: _parameter_validation_error,
+        TemplateRetrievalError: _retrieval_error,
         GenericParsingError: _simple_error_formatter,
     }
     formatter = formatters.get(type(error), _default_error_message)

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
         "requests",
         "six",
         "tabulate",
-        "faculty",
+        "faculty==0.26.4.dev3",
     ],
     entry_points={"console_scripts": ["faculty=faculty_cli.cli:cli"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
         "requests",
         "six",
         "tabulate",
-        "faculty==0.26.4.dev4",
+        "faculty==0.26.4.dev5",
     ],
     entry_points={"console_scripts": ["faculty=faculty_cli.cli:cli"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
         "requests",
         "six",
         "tabulate",
-        "faculty==0.26.4.dev3",
+        "faculty==0.26.4.dev4",
     ],
     entry_points={"console_scripts": ["faculty=faculty_cli.cli:cli"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
         "requests",
         "six",
         "tabulate",
-        "faculty==0.26.4.dev2",
+        "faculty",
     ],
     entry_points={"console_scripts": ["faculty=faculty_cli.cli:cli"]},
 )

--- a/test/test_templates.py
+++ b/test/test_templates.py
@@ -1,4 +1,5 @@
 import os
+import textwrap
 import uuid
 
 from click.testing import CliRunner
@@ -6,11 +7,28 @@ import pytest
 
 from faculty_cli.cli import cli
 from faculty.clients.account import AccountClient
-from faculty.clients.template import TemplateClient
+from faculty.clients.template import (
+    TemplateClient,
+    GenericParsingError,
+    DefaultParametersParsingError,
+    ResourceValidationFailure,
+    AppValidationFailure,
+    ApiValidationFailure,
+    EnvironmentValidationFailure,
+    JobValidationFailure,
+    WorkspaceValidationFailure,
+    ParameterValidationFailure, TemplateRetrievalFailure,
+)
 from faculty.clients.notification import NotificationClient
+from faculty.clients.project import Project
 
 USER_ID = uuid.uuid4()
-PROJECT_ID = uuid.uuid4()
+SOURCE_PROJECT_ID = uuid.uuid4()
+TARGET_PROJECT_ID = uuid.uuid4()
+
+TARGET_PROJECT = Project(
+    id=TARGET_PROJECT_ID, name="target-project", owner_id=USER_ID
+)
 
 
 def test_init():
@@ -44,7 +62,7 @@ def test_publish_new_template_success(mocker):
     )
     mocker.patch("os.path.abspath", return_value="/project/src/")
     mock_notifications = mocker.Mock()
-    get_notifications_mock = mocker.patch.object(
+    notifications_mock = mocker.patch.object(
         NotificationClient,
         "publish_template_notifications",
         return_value=mock_notifications,
@@ -52,14 +70,16 @@ def test_publish_new_template_success(mocker):
     publish_new_mock = mocker.patch.object(TemplateClient, "publish_new")
 
     runner = CliRunner(
-        mix_stderr=False, env={"FACULTY_PROJECT_ID": str(PROJECT_ID)}
+        mix_stderr=False, env={"FACULTY_PROJECT_ID": str(SOURCE_PROJECT_ID)}
     )
     result = runner.invoke(cli, ["template", "publish", "new", "name"])
     assert result.exit_code == 0
     assert result.stdout == "Successfully published template `name`.\n"
 
-    get_notifications_mock.assert_called_once_with(USER_ID, PROJECT_ID)
-    publish_new_mock.assert_called_once_with(PROJECT_ID, "name", "/src/")
+    notifications_mock.assert_called_once_with(USER_ID, SOURCE_PROJECT_ID)
+    publish_new_mock.assert_called_once_with(
+        SOURCE_PROJECT_ID, "name", "/src/"
+    )
     mock_notifications.wait_for_completion.assert_called_once_with()
 
 
@@ -84,7 +104,7 @@ def test_publish_new_template_custom_source_dir(
     )
     mocker.patch("os.path.abspath", return_value=mock_abs_src_dir)
     mock_notifications = mocker.Mock()
-    get_notifications_mock = mocker.patch.object(
+    notifications_mock = mocker.patch.object(
         NotificationClient,
         "publish_template_notifications",
         return_value=mock_notifications,
@@ -92,7 +112,7 @@ def test_publish_new_template_custom_source_dir(
     publish_new_mock = mocker.patch.object(TemplateClient, "publish_new")
 
     runner = CliRunner(
-        mix_stderr=False, env={"FACULTY_PROJECT_ID": str(PROJECT_ID)}
+        mix_stderr=False, env={"FACULTY_PROJECT_ID": str(SOURCE_PROJECT_ID)}
     )
     result = runner.invoke(
         cli, ["template", "publish", "new", "name", input_src_dir]
@@ -100,9 +120,9 @@ def test_publish_new_template_custom_source_dir(
     assert result.exit_code == 0
     assert result.stdout == "Successfully published template `name`.\n"
 
-    get_notifications_mock.assert_called_once_with(USER_ID, PROJECT_ID)
+    notifications_mock.assert_called_once_with(USER_ID, SOURCE_PROJECT_ID)
     publish_new_mock.assert_called_once_with(
-        PROJECT_ID, "name", expected_src_dir
+        SOURCE_PROJECT_ID, "name", expected_src_dir
     )
     mock_notifications.wait_for_completion.assert_called_once_with()
 
@@ -113,7 +133,7 @@ def test_publish_new_template_outside_project(mocker):
     )
     mocker.patch("os.path.abspath", return_value="/outside/project")
     runner = CliRunner(
-        mix_stderr=False, env={"FACULTY_PROJECT_ID": str(PROJECT_ID)}
+        mix_stderr=False, env={"FACULTY_PROJECT_ID": str(SOURCE_PROJECT_ID)}
     )
     result = runner.invoke(
         cli, ["template", "publish", "new", "name", "/outside/project"]
@@ -122,4 +142,177 @@ def test_publish_new_template_outside_project(mocker):
     assert result.stderr == (
         "Source directory must be under /project. "
         "This command is meant to be used from inside a Faculty server.\n"
+    )
+
+
+def test_add_to_project_from_directory(mocker):
+    mocker.patch.object(
+        AccountClient, "authenticated_user_id", return_value=USER_ID
+    )
+    mocker.patch(
+        "faculty_cli.cli._list_projects", return_value=[TARGET_PROJECT]
+    )
+    mocker.patch("os.path.abspath", return_value="/project/src/")
+    mock_notifications = mocker.Mock()
+    notifications_mock = mocker.patch.object(
+        NotificationClient,
+        "add_to_project_from_dir_notifications",
+        return_value=mock_notifications,
+    )
+    add_to_project_from_directory_mock = mocker.patch.object(
+        TemplateClient, "add_to_project_from_directory"
+    )
+
+    runner = CliRunner(
+        mix_stderr=False, env={"FACULTY_PROJECT_ID": str(SOURCE_PROJECT_ID)}
+    )
+    result = runner.invoke(
+        cli,
+        [
+            "template",
+            "add-to-project-from-directory",
+            "target-project",
+            "-p",
+            "param1",
+            "1",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert (
+        result.stdout
+        == "Successfully applied template to project target-project.\n"
+    )
+
+    notifications_mock.assert_called_once_with(USER_ID, TARGET_PROJECT_ID)
+    add_to_project_from_directory_mock.assert_called_once_with(
+        SOURCE_PROJECT_ID, "/src/", TARGET_PROJECT_ID, "/", {"param1": "1"}
+    )
+    mock_notifications.wait_for_completion.assert_called_once_with()
+
+
+@pytest.mark.parametrize(
+    "mock_exception, expected_message",
+    [
+        (
+            GenericParsingError("generic parsing error"),
+            "generic parsing error\n",
+        ),
+        (
+            DefaultParametersParsingError("param parsing error"),
+            "param parsing error\n",
+        ),
+        (
+            ResourceValidationFailure(
+                apps=AppValidationFailure(
+                    subdomain_conflicts=["app-subdomain-1"],
+                    name_conflicts=["test-app-name-1", "test-app-name-2"],
+                    invalid_working_dirs=["invalid/app/dir"],
+                ),
+                apis=ApiValidationFailure(
+                    subdomain_conflicts=["api-subdomain-1"],
+                    name_conflicts=["test-api-name"],
+                    invalid_working_dirs=["invalid/API/dir"],
+                ),
+                environments=EnvironmentValidationFailure(
+                    name_conflicts=["test-env-name"],
+                    invalid_names=["invalid#env"],
+                ),
+                jobs=JobValidationFailure(
+                    name_conflicts=["test-job-name"],
+                    invalid_working_dirs=[],
+                    invalid_names=["invalid#job"],
+                ),
+                workspace=WorkspaceValidationFailure(
+                    name_conflicts=["test-file-path"]
+                ),
+            ),
+            textwrap.dedent("""\
+                    App subdomain already exists: app-subdomain-1
+                    App name already exists: test-app-name-1
+                    App name already exists: test-app-name-2
+                    Invalid app working directory: invalid/app/dir
+                    API subdomain already exists: api-subdomain-1
+                    API name already exists: test-api-name
+                    Invalid API working directory: invalid/API/dir
+                    Environment name already exists: test-env-name
+                    Invalid environment name: invalid#env
+                    Job name already exists: test-job-name
+                    Invalid job name: invalid#job
+                    Workspace file already exists: test-file-path
+                """
+            ),
+        ),
+        (
+            ParameterValidationFailure(
+                errors=["test param 1 error", "test param 2 error"]
+            ),
+            textwrap.dedent(
+                """\
+                Parameter validation failed: test param 1 error
+                Parameter validation failed: test param 2 error
+            """
+            ),
+        ),
+        (
+            TemplateRetrievalFailure(
+                apps=["app error"],
+                apis=["API error"],
+                environments=["env error"],
+                jobs=["job error"],
+            ),
+            textwrap.dedent(
+                """\
+                Error reading app resource definition: app error
+                Error reading API resource definition: API error
+                Error reading environment resource definition: env error
+                Error reading app job definition: job error
+            """
+            ),
+        ),
+    ],
+)
+def test_add_to_project_from_directory_validation_errors(
+    mocker, mock_exception, expected_message
+):
+    mocker.patch.object(
+        AccountClient, "authenticated_user_id", return_value=USER_ID
+    )
+    mocker.patch(
+        "faculty_cli.cli._list_projects", return_value=[TARGET_PROJECT]
+    )
+    mocker.patch("os.path.abspath", return_value="/project/src/")
+    mock_notifications = mocker.Mock()
+    notifications_mock = mocker.patch.object(
+        NotificationClient,
+        "add_to_project_from_dir_notifications",
+        return_value=mock_notifications,
+    )
+    add_to_project_from_directory_mock = mocker.patch.object(
+        TemplateClient,
+        "add_to_project_from_directory",
+        side_effect=mock_exception,
+    )
+
+    runner = CliRunner(
+        mix_stderr=False, env={"FACULTY_PROJECT_ID": str(SOURCE_PROJECT_ID)}
+    )
+    result = runner.invoke(
+        cli,
+        [
+            "template",
+            "add-to-project-from-directory",
+            "target-project",
+            "-p",
+            "param1",
+            "1",
+        ],
+    )
+
+    assert result.exit_code == 64
+    assert result.stderr == expected_message
+
+    notifications_mock.assert_called_once_with(USER_ID, TARGET_PROJECT_ID)
+    add_to_project_from_directory_mock.assert_called_once_with(
+        SOURCE_PROJECT_ID, "/src/", TARGET_PROJECT_ID, "/", {"param1": "1"}
     )

--- a/test/test_templates.py
+++ b/test/test_templates.py
@@ -11,14 +11,14 @@ from faculty.clients.template import (
     TemplateClient,
     GenericParsingError,
     DefaultParametersParsingError,
-    ResourceValidationFailure,
+    ResourceValidationError,
     AppValidationFailure,
     ApiValidationFailure,
     EnvironmentValidationFailure,
     JobValidationFailure,
     WorkspaceValidationFailure,
-    ParameterValidationFailure,
-    TemplateRetrievalFailure,
+    ParameterValidationError,
+    TemplateRetrievalError,
 )
 from faculty.clients.notification import NotificationClient
 from faculty.clients.project import Project
@@ -49,7 +49,7 @@ PUBLISHING_ERRORS = [
         "param parsing error\n",
     ),
     (
-        ResourceValidationFailure(
+        ResourceValidationError(
             apps=AppValidationFailure(
                 subdomain_conflicts=["app-subdomain-1"],
                 name_conflicts=["test-app-name-1", "test-app-name-2"],
@@ -90,7 +90,7 @@ PUBLISHING_ERRORS = [
         ),
     ),
     (
-        ParameterValidationFailure(
+        ParameterValidationError(
             errors=["test param 1 error", "test param 2 error"]
         ),
         textwrap.dedent(
@@ -101,7 +101,7 @@ PUBLISHING_ERRORS = [
         ),
     ),
     (
-        TemplateRetrievalFailure(
+        TemplateRetrievalError(
             apps=["app error"],
             apis=["API error"],
             environments=["env error"],

--- a/test/test_templates.py
+++ b/test/test_templates.py
@@ -46,7 +46,7 @@ def test_publish_new_template_success(mocker):
     mock_notifications = mocker.Mock()
     get_notifications_mock = mocker.patch.object(
         NotificationClient,
-        "get_publish_template_notifications",
+        "publish_template_notifications",
         return_value=mock_notifications,
     )
     publish_new_mock = mocker.patch.object(TemplateClient, "publish_new")
@@ -86,7 +86,7 @@ def test_publish_new_template_custom_source_dir(
     mock_notifications = mocker.Mock()
     get_notifications_mock = mocker.patch.object(
         NotificationClient,
-        "get_publish_template_notifications",
+        "publish_template_notifications",
         return_value=mock_notifications,
     )
     publish_new_mock = mocker.patch.object(TemplateClient, "publish_new")


### PR DESCRIPTION
This implements the `faculty template add-to-project-from-directory` command.

Some of the bits were reused from `faculty template publish` + translation of typed errors from the client to human-readable exception was added.

This uses depends on [this PR](https://github.com/facultyai/faculty/pull/175).