### PR TITLE
Send token in auth header when talking to Hound

### DIFF
--- a/faculty_cli/__init__.py
+++ b/faculty_cli/__init__.py
@@ -1,5 +1,3 @@
-"""The command line interface to the Faculty platform."""
-
 # Copyright 2016-2020 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,3 +11,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""The command line interface to the Faculty platform."""

--- a/faculty_cli/auth.py
+++ b/faculty_cli/auth.py
@@ -1,5 +1,3 @@
-"""Authenticate with Faculty."""
-
 # Copyright 2016-2020 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""Authenticate with Faculty."""
 
 import json
 import os

--- a/faculty_cli/cli.py
+++ b/faculty_cli/cli.py
@@ -1,5 +1,3 @@
-"""Command line interface."""
-
 # Copyright 2016-2020 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""Command line interface."""
 
 from __future__ import division
 

--- a/faculty_cli/client.py
+++ b/faculty_cli/client.py
@@ -1,5 +1,3 @@
-"""Interact with a Faculty service."""
-
 # Copyright 2016-2020 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""Interact with a Faculty service."""
 
 import json
 from contextlib import contextmanager

--- a/faculty_cli/client.py
+++ b/faculty_cli/client.py
@@ -76,8 +76,7 @@ class FacultyService(object):
     @property
     def _headers(self):
         headers = {"User-Agent": faculty_cli.version.user_agent()}
-        if not self.cookie_auth:
-            headers.update(faculty_cli.auth.auth_headers())
+        headers.update(faculty_cli.auth.auth_headers())
         return headers
 
     @property

--- a/faculty_cli/config.py
+++ b/faculty_cli/config.py
@@ -1,5 +1,3 @@
-"""Configuration helpers."""
-
 # Copyright 2016-2020 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""Configuration helpers."""
 
 import faculty.config
 

--- a/faculty_cli/hound.py
+++ b/faculty_cli/hound.py
@@ -1,5 +1,3 @@
-"""Interact with Hound."""
-
 # Copyright 2016-2020 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Interact with Hound."""
 
 import requests
 

--- a/faculty_cli/parse.py
+++ b/faculty_cli/parse.py
@@ -1,3 +1,17 @@
+# Copyright 2016-2020 Faculty Science Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from collections import namedtuple
 
 ESCAPE_CHAR = "\\"

--- a/faculty_cli/shell.py
+++ b/faculty_cli/shell.py
@@ -1,7 +1,6 @@
 """Shell helper functions.
 
 Vendored from https://github.com/python/cpython/blob/3.6/Lib/shlex.py
-
 """
 
 # Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,

--- a/faculty_cli/update.py
+++ b/faculty_cli/update.py
@@ -1,5 +1,3 @@
-"""Prompt the user to update the Faculty CLI."""
-
 # Copyright 2016-2020 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""Prompt the user to update the Faculty CLI."""
 
 import errno
 import os

--- a/faculty_cli/version.py
+++ b/faculty_cli/version.py
@@ -1,5 +1,3 @@
-"""Module version information."""
-
 # Copyright 2016-2020 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""Module version information."""
 
 import platform
 from pkg_resources import get_distribution, DistributionNotFound

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-"""Setup module for the Faculty CLI."""
-
 # Copyright 2016-2020 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2016-2020 Faculty Science Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,3 +1,17 @@
+# Copyright 2016-2020 Faculty Science Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import pytest
 
 from test.fixtures import PROFILE, USER_ID

--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -1,3 +1,17 @@
+# Copyright 2016-2020 Faculty Science Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import uuid
 import datetime
 

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,3 +1,17 @@
+# Copyright 2016-2020 Faculty Science Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import faculty_cli.config
 
 

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -1,3 +1,17 @@
+# Copyright 2016-2020 Faculty Science Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import pytest
 from click.testing import CliRunner
 

--- a/test/test_parse.py
+++ b/test/test_parse.py
@@ -1,3 +1,17 @@
+# Copyright 2016-2020 Faculty Science Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import pytest
 
 from faculty_cli.parse import (

--- a/test/test_projects.py
+++ b/test/test_projects.py
@@ -1,3 +1,17 @@
+# Copyright 2016-2020 Faculty Science Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import pytest
 from click.testing import CliRunner
 

--- a/test/test_servers.py
+++ b/test/test_servers.py
@@ -1,3 +1,17 @@
+# Copyright 2016-2020 Faculty Science Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from click.testing import CliRunner
 
 from faculty_cli.cli import cli, _server_spec

--- a/tox.ini
+++ b/tox.ini
@@ -21,3 +21,10 @@ deps =
     black==18.9b0
 commands =
     black {posargs:--check setup.py faculty_cli test}
+
+[testenv:license]
+skip_install = True
+deps =
+    apache-license-check
+commands =
+    apache-license-check setup.py faculty_cli test --exclude faculty_cli/shell.py --copyright "Faculty Science Limited"


### PR DESCRIPTION
For the moment, continue to send the token as a cookie so that the CLI continues to work for existing servers.