### PR TITLE
Send token in auth header when talking to Hound

### DIFF
--- a/faculty_cli/client.py
+++ b/faculty_cli/client.py
@@ -76,8 +76,7 @@ class FacultyService(object):
     @property
     def _headers(self):
         headers = {"User-Agent": faculty_cli.version.user_agent()}
-        if not self.cookie_auth:
-            headers.update(faculty_cli.auth.auth_headers())
+        headers.update(faculty_cli.auth.auth_headers())
         return headers
 
     @property


### PR DESCRIPTION
For the moment, continue to send the token as a cookie so that the CLI continues to work for existing servers.