### PR TITLE
update Python versions from test matrix and make 3.9 the default for lint

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.6, 3.7, 3.8, 3.9, '3.10']
+        python: [3.7, 3.8, 3.9, '3.10', 3.11]
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Install Tox
         run: pip install tox
       - name: Run linter


### PR DESCRIPTION
Python 3.6 is no longer provided by the GitHub action, so that's removed. 3.11 is now provided and it's useful to test. The Platform uses 3.9 by default now, so that is useful to set as a default.